### PR TITLE
Fix Reconcilition delete from statement

### DIFF
--- a/statement.py
+++ b/statement.py
@@ -331,7 +331,7 @@ class Reconciliation(metaclass=PoolMeta):
         from_statement = Transaction().context.get(
             'from_account_bank_statement_line', False)
         if from_statement:
-            super(Reconciliation, cls).delete(reconciliations)
+            return super(Reconciliation, cls).delete(reconciliations)
 
         cls.check_bank_statement_lines(reconciliations)
         return super(Reconciliation, cls).delete(reconciliations)


### PR DESCRIPTION
Bug introduced on  [commit](https://github.com/trytonspain/trytond-account_bank_statement_counterpart/commit/715a93c774a2663f970f8f87194d8ebca2d7f31a)

In case a reconciliation is deleted, the code tries to read fields from an already deleted reconciliation.